### PR TITLE
Update bastille-init

### DIFF
--- a/bastille-init
+++ b/bastille-init
@@ -221,7 +221,7 @@ bastille_upgrade()
 			rm -f ${CWDIR}/update/${APPNAME}
 			chmod 555 ${CWDIR}/update/${BASTILLEPATH}/${APPNAME}
 			chmod 555 ${CWDIR}/${FULLAPPNAME}${BASTILLERCD}
-			cp -Rf ${CWDIR}/update/* ${CWDIR}/${FULLAPPNAME}/
+			cp -Rf ${CWDIR}/update/* ${CWDIR}/${FULLAPPNAME}
 			rm -R ${CWDIR}/update
 
 			# Logging the update event.


### PR DESCRIPTION
BUGFIX:

`/usr/sbin/sysrc: cannot create /tmp/bastile/bastille-dist//usr/local/etc/bastille/bastille.conf: No such file or directory
grep: /tmp/bastile/bastille-dist//usr/local/etc/bastille/bastille.conf: No such file or directory
grep: /tmp/bastile/bastille-dist//usr/local/etc/bastille/bastille.conf: No such file or directory`
