### PR TITLE
-y is needed for destroy now

### DIFF
--- a/gui/bastille_manager_util.php
+++ b/gui/bastille_manager_util.php
@@ -390,9 +390,9 @@ if($_POST):
 						break;
 					else:
 						if (isset($_POST['nowstop'])):
-							$cmd = ("/usr/local/bin/bastille destroy -f {$item}");
+							$cmd = ("/usr/local/bin/bastille destroy -afy {$item}");
 						else:
-							$cmd = ("/usr/local/bin/bastille destroy {$item}");
+							$cmd = ("/usr/local/bin/bastille destroy -y {$item}");
 						endif;
 						unset($output,$retval);mwexec2($cmd,$output,$retval);
 						if($retval == 0):


### PR DESCRIPTION
Recently add -y to auto destroy, otherwise a prompt is given.