### PR TITLE
Parse the interface again, Added another case

### DIFF
--- a/gui/bastille_manager-lib.inc
+++ b/gui/bastille_manager-lib.inc
@@ -177,6 +177,24 @@ function get_all_interface_list() {
 	return $iflist;
 }
 
+function bastille_get_jail_interface($conf_path) {
+    if (file_exists($conf_path)) {
+        $lines = @file($conf_path);
+        if ($lines) {
+            foreach ($lines as $line) {
+                // Case 1: VNET or interface
+                if (preg_match('/(?:vnet\.)?interface\s*=\s*"?([^";\s]+)/', $line, $matches)) {
+                    return $matches[1];
+                } // Case 2: (ip4.addr = nic|ip;)
+                elseif (preg_match('/ip4\.addr\s*=\s*"?([^|";\s]+)\|/', $line, $matches)) {
+                    return $matches[1];
+                }
+            }
+        }
+    }
+    return '-';
+}
+
 //	list base releases
 $a_release = get_all_release_list();
 $l_release = [];
@@ -340,37 +358,8 @@ function get_jail_infos() {
 			$r['stat'] = $img_path['dis'];
 		}
 
-        global $bastille_prefix;
-        if (!isset($bastille_prefix)) {
-            $bastille_prefix = '/usr/local/bastille';
-            $b_conf = '/usr/local/etc/bastille/bastille.conf';
-            if (file_exists($b_conf)) {
-                $lines = @file($b_conf);
-                if ($lines) {
-                    foreach ($lines as $line) {
-                        if (preg_match('/^bastille_prefix="?(.*?)"?$/', trim($line), $matches)) {
-                            $bastille_prefix = $matches[1];
-                            break;
-                        }
-                    }
-                }
-            }
-        }
-
-        $r['interface'] = '-';
-        $jail_conf_file = "{$bastille_prefix}/jails/{$item}/jail.conf";
-
-        if (file_exists($jail_conf_file)) {
-            $lines = @file($jail_conf_file);
-            if ($lines) {
-                foreach ($lines as $line) {
-                    if (preg_match('/(?:vnet\.)?interface\s*=\s*"?([^";\s]+)/', $line, $matches)) {
-                        $r['interface'] = $matches[1];
-                        break;
-                    }
-                }
-            }
-        }
+        $jail_conf_file = "{$jail_dir}/{$item}/jail.conf";
+        $r['interface'] = bastille_get_jail_interface($jail_conf_file);
 
 		// Display custom template icons if available
 		$template_icon = "{$jail_dir}/{$item}/plugin_icon.png";

--- a/gui/bastille_manager_gui.php
+++ b/gui/bastille_manager_gui.php
@@ -153,7 +153,8 @@ if ($_POST):
         endforeach;
 
         if (!empty($commands)):
-            $executor = new BastilleManagerMwExecParallel($commands);
+            $executor = new
+            ($commands);
             $results = $executor->executeWithSelect();
 
             $success_count = 0;
@@ -837,32 +838,10 @@ endif;
 					<td class="lcell"><?=htmlspecialchars($sphere_record['rel']);?>&nbsp;</td>
 					<td class="lcell"><?=htmlspecialchars($sphere_record['tags']);?>&nbsp;</td>
                     <?php
-                            if (!isset($bastille_prefix)) {
-                                $bastille_prefix = '/usr/local/bastille';
-                                $b_conf = '/usr/local/etc/bastille/bastille.conf';
-                                if (file_exists($b_conf)) {
-                                    $lines = file($b_conf);
-                                    foreach ($lines as $line) {
-                                        if (preg_match('/^bastille_prefix="?(.*?)"?$/', trim($line), $matches)) {
-                                            $bastille_prefix = $matches[1];
-                                            break;
-                                        }
-                                    }
-                                }
-                            }
-    $jname = $sphere_record['jailname'];
-    $jail_conf_file = "{$bastille_prefix}/jails/{$jname}/jail.conf";
-    $jail_interface = '-';
-    if (file_exists($jail_conf_file)) {
-        $lines = file($jail_conf_file);
-        foreach ($lines as $line) {
-            if (preg_match('/(?:vnet\.)?interface\s*=\s*"?([^";\s]+)/', $line, $matches)) {
-                $jail_interface = $matches[1];
-                break;
-            }
-        }
-    }
-    ?>
+                            $jname = $sphere_record['jailname'];
+                            $jail_conf_file = "{$jail_dir}/{$jname}/jail.conf";
+                            $jail_interface = bastille_get_jail_interface($jail_conf_file);
+                    ?>
                     <td class="lcell"><?=htmlspecialchars($jail_interface);?>&nbsp;</td>
 					<td class="lcell"><img src="<?=$sphere_record['stat'];?>"></td>
 					<td class="lcell"><img src="<?=$sphere_record['logo'];?>"></td>


### PR DESCRIPTION
Follow  #47

- New `bastille_get_jail_interface function` To use it in `bastille_manager_lib.inc` for caching and in the `bastille_manager_gui.php`

Hi @JRGTH 

We have an old function that uses low-performance subprocesses. Right now, we're using PHP with this new function to read “jail.conf” using the variables you created for that specific path.

This is the old function `get_all_interface_list`; we're not using it anywhere right now, just loading this variable `$l_interfaces`.

Whatever you say—if you want, we can take it down. It's up to you.

---

<img width="1786" height="239" alt="image" src="https://github.com/user-attachments/assets/cdb3fe94-8506-4de7-a6f2-253aecc593c4" />
