### PR TITLE
XigmaNAS Top-down menu focus issue

### DIFF
--- a/gui/bastille_manager_gui.php
+++ b/gui/bastille_manager_gui.php
@@ -893,30 +893,29 @@ endforeach;
 		<input name="autoboot_selected_jail" id="autoboot_selected_jail" type="submit" class="formbtn" value="<?=$gt_selection_autoboot;?>"/>
 	</div>
 
-    <div id="web-terminal-modal">
-        <div id="web-terminal-content">
-            <div id="web-terminal-header">
-                <span id="web-terminal-title"></span>
-                <img src="ext/bastille/images/info-ssl.svg" class="icon-svg ssl-help-icon"
-                         title="MOZILLA_PKIX_ERROR_SELF_SIGNED_CERT Mozilla will display this initial warning, to fix it: Use the button “Open in New Tab” (Top right corner, in this window)" />
-                <div id="web-terminal-right-buttons">
-                    <a href="#" id="web-terminal-fullscreen" class="web-terminal-btn-fullscreen" title="Fullscreen">
-                        <img src="ext/bastille/images/fullscreen.svg" class="icon-svg fullscreen-icon-darkbg" alt="Fullscreen" />
-                     </a>
-                    <a href="#" id="web-terminal-popout" class="web-terminal-btn-open-tab">Open in New Tab</a>
-                    <span id="web-terminal-close" style="cursor:pointer; font-weight:bold; font-size:1.3em;">&times;</span>
-                </div>
-            </div>
-            <div id="web-terminal-iframe-container">
-                <iframe id="web-terminal-iframe" src="about:blank"></iframe>
-            </div>
-        </div>
-    </div>
-
 <?php
     include 'formend.inc';
 ?>
 </td></tr></tbody></table></form>
+    <div id="web-terminal-modal">
+            <div id="web-terminal-content">
+                <div id="web-terminal-header">
+                    <span id="web-terminal-title"></span>
+                    <img src="ext/bastille/images/info-ssl.svg" class="icon-svg ssl-help-icon"
+                             title="MOZILLA_PKIX_ERROR_SELF_SIGNED_CERT Mozilla will display this initial warning, to fix it: Use the button “Open in New Tab” (Top right corner, in this window)" />
+                    <div id="web-terminal-right-buttons">
+                        <a href="#" id="web-terminal-fullscreen" class="web-terminal-btn-fullscreen" title="Fullscreen">
+                            <img src="ext/bastille/images/fullscreen.svg" class="icon-svg fullscreen-icon-darkbg" alt="Fullscreen" />
+                         </a>
+                        <a href="#" id="web-terminal-popout" class="web-terminal-btn-open-tab">Open in New Tab</a>
+                        <span id="web-terminal-close" style="cursor:pointer; font-weight:bold; font-size:1.3em;">&times;</span>
+                    </div>
+                </div>
+                <div id="web-terminal-iframe-container">
+                    <iframe id="web-terminal-iframe" src="about:blank"></iframe>
+                </div>
+            </div>
+    </div>
 <?php
 include 'fend.inc';
 ?>

--- a/gui/css/styles.css
+++ b/gui/css/styles.css
@@ -19,3 +19,8 @@
   --icon-size-container: 20px;
   --icon-color: #777777;
 }
+
+#area_data_frame {
+  position: relative;
+  z-index: 1;
+}


### PR DESCRIPTION
- [x] Added custom `z-index` for `area_data_frame` id
- [x] This was affecting the full width of the web terminal; we resolved it by moving the div out of the table.

---
- Tested with Mozilla Firefox and Google Chrome on Ubuntu 24.04
- Tested with Microsoft Edge on Windows 11